### PR TITLE
Allow multiple TraTs consumption and verification for APIs

### DIFF
--- a/service/verificationrules/v1alpha1/rules.go
+++ b/service/verificationrules/v1alpha1/rules.go
@@ -224,11 +224,9 @@ func (vri *VerificationRulesImp) ApplyRule(trat *trat.TraT, path string, method 
 
 			return valid, "", nil
 		}
-
 	}
 
 	return false, "invalid authorization details", err
-
 }
 
 func (vri *VerificationRulesImp) validateAzd(azdMapping AzdMapping, input map[string]interface{}, trat *trat.TraT) (bool, error) {


### PR DESCRIPTION
This PR fixes the bug of APIs being able to consume and verify only one TraT. Many APIs, especially from general services such as customer service, are invoked by multiple different external APIs and, thus, must consume and verify multiple TraTs.